### PR TITLE
[patch] Don't try to guess name of conda env by 'env'

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     sha256: cda199182eda0e757f5021d08453090234585f35c6f628336197c6d85883027d
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: cd dist && python -m pip install --no-deps --ignore-installed .
 

--- a/recipe/osx_freecad_path.patch
+++ b/recipe/osx_freecad_path.patch
@@ -1,11 +1,30 @@
 --- a/cadquery/freecad_impl/__init__.py
 +++ b/cadquery/freecad_impl/__init__.py
-@@ -63,7 +63,7 @@ def _fc_path():
+@@ -62,17 +62,16 @@ def _fc_path():
+         return _PATH
 
      # Try to guess if using Anaconda
-     if 'env' in sys.prefix:
+-    if 'env' in sys.prefix:
 -        if sys.platform.startswith('linux'):
-+        if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
-             _PATH = os.path.join(sys.prefix,'lib')
-             # return PATH if FreeCAD.[so,pyd] is present
-             if len(glob.glob(os.path.join(_PATH,'FreeCAD.so'))) > 0:
+-            _PATH = os.path.join(sys.prefix,'lib')
+-            # return PATH if FreeCAD.[so,pyd] is present
+-            if len(glob.glob(os.path.join(_PATH,'FreeCAD.so'))) > 0:
+-                return _PATH
+-        elif sys.platform.startswith('win'):
+-            _PATH = os.path.join(sys.prefix,'Library','bin')
+-            # return PATH if FreeCAD.[so,pyd] is present
+-            if len(glob.glob(os.path.join(_PATH,'FreeCAD.pyd'))) > 0:
+-                return _PATH
++    if sys.platform.startswith('linux'):
++        _PATH = os.path.join(sys.prefix,'lib')
++        # return PATH if FreeCAD.[so,pyd] is present
++        if len(glob.glob(os.path.join(_PATH,'FreeCAD.so'))) > 0:
++            return _PATH
++    elif sys.platform.startswith('win'):
++        _PATH = os.path.join(sys.prefix,'Library','bin')
++        # return PATH if FreeCAD.[so,pyd] is present
++        if len(glob.glob(os.path.join(_PATH,'FreeCAD.pyd'))) > 0:
++            return _PATH
+
+     if sys.platform.startswith('linux'):
+         # Make some dangerous assumptions...


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Didn't make the issue yet, but the root is that the patch extended on the upstream checking for the string literal `env`, which won't catch a `root`/`base` install.

<!--
Please add any other relevant info below:
-->
Updated the patch to just check if `sys.prefix/{lib,Library/bin}/FreeCAD.{so,pyd}` exist. 